### PR TITLE
Fix unittest import error

### DIFF
--- a/src/test_cam.py
+++ b/src/test_cam.py
@@ -1,13 +1,28 @@
-import cv2
+"""Utility for testing camera input.
+
+This module is intentionally simple and is not run during automated tests.
+If OpenCV (``cv2``) is not available, the ``main`` function will simply exit
+without raising an ImportError so that ``unittest`` discovery does not fail.
+"""
+
+try:
+    import cv2
+except Exception:  # pragma: no cover - handled for environments without cv2
+    cv2 = None
 
 VIDEO_SOURCE = 0
 
 
 def main():
+    if cv2 is None:
+        print("OpenCV is not installed; skipping camera test.")
+        return
+
     cap = cv2.VideoCapture(VIDEO_SOURCE)
     if not cap.isOpened():
         print("Cannot open camera")
-        exit()
+        return
+
     while True:
         # Capture frame-by-frame
         ret, frame = cap.read()


### PR DESCRIPTION
## Summary
- prevent `test_cam.py` from failing when OpenCV isn't available

## Testing
- `python -m unittest discover src`

------
https://chatgpt.com/codex/tasks/task_e_683ff0d35bd8832eac0357de3e4e3ba0