### PR TITLE
Add metrics with Prometheus and Grafana

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ FACE_CONF_THR=0.6
 also uses `SAVE_API_URL` to post events to the web API, which is already set to
 `http://web:8000/api/save` when running through Docker Compose.
 
+## Monitoring
+
+The stack includes Prometheus and Grafana. Prometheus scrapes metrics from the
+web server on port `8000/metrics` and from the detector on port `8001`. Grafana
+is exposed on `http://localhost:3000` with Prometheus configured as a data
+source.
+
 ## Running
 
 Start the entire stack in the background using the Makefile target:
@@ -47,7 +54,8 @@ make dev
 
 This command simply invokes Docker Compose as defined in
 `docker-compose.yml`.  After the containers are up you can reach the web UI at
-`http://localhost:8000` and phpMyAdmin at `http://localhost:8081`.
+`http://localhost:8000`, phpMyAdmin at `http://localhost:8081`, Prometheus at
+`http://localhost:9090` and Grafana at `http://localhost:3000`.
 
 To stop and remove the containers use:
 
@@ -74,6 +82,7 @@ The shell hook creates a virtual environment and installs the dependencies from
 - `docker-compose.yml` – orchestrates the services
 - `Dockerfile` – base image used for both web and detector services
 - `Dockerfile.dev` – development image with hot reload using entr
+- `prometheus.yml` – Prometheus scrape configuration
 - `mysql_init/` – database initialization SQL
 - `Makefile` – convenience targets for running and building the project
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,5 +60,20 @@ services:
       - "8081:80"
     depends_on:
       - mysql
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    depends_on:
+      - web
+      - detect
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
 volumes:
   mysql_data:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'web'
+    static_configs:
+      - targets: ['web:8000']
+  - job_name: 'detect'
+    static_configs:
+      - targets: ['detect:8001']

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytz
 requests
 tf-keras
 uvicorn
+prometheus-client

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -9,6 +9,16 @@ dummy_module = types.ModuleType("dummy")
 sys.modules.setdefault("cv2", dummy_module)
 sys.modules.setdefault("requests", dummy_module)
 
+prom_stub = types.ModuleType("prometheus_client")
+
+class DummyCounter:
+    def inc(self):
+        pass
+
+prom_stub.Counter = lambda *args, **kwargs: DummyCounter()
+prom_stub.start_http_server = lambda *args, **kwargs: None
+sys.modules["prometheus_client"] = prom_stub
+
 dotenv_stub = types.ModuleType("dotenv")
 dotenv_stub.load_dotenv = lambda: None
 sys.modules.setdefault("dotenv", dotenv_stub)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -26,6 +26,7 @@ fastapi_staticfiles.StaticFiles = MagicMock()
 fastapi_responses = types.ModuleType("fastapi.responses")
 fastapi_responses.HTMLResponse = MagicMock()
 fastapi_responses.JSONResponse = MagicMock()
+fastapi_responses.Response = MagicMock()
 
 sys.modules.setdefault("fastapi", fastapi_stub)
 sys.modules.setdefault("fastapi.staticfiles", fastapi_staticfiles)
@@ -34,6 +35,16 @@ sys.modules.setdefault("fastapi.responses", fastapi_responses)
 uvicorn_stub = types.ModuleType("uvicorn")
 uvicorn_stub.run = MagicMock()
 sys.modules.setdefault("uvicorn", uvicorn_stub)
+
+dotenv_stub = types.ModuleType("dotenv")
+dotenv_stub.load_dotenv = lambda: None
+sys.modules.setdefault("dotenv", dotenv_stub)
+
+prometheus_stub = types.ModuleType("prometheus_client")
+prometheus_stub.Counter = MagicMock(return_value=MagicMock())
+prometheus_stub.generate_latest = MagicMock(return_value=b"")
+prometheus_stub.CONTENT_TYPE_LATEST = "text/plain"
+sys.modules["prometheus_client"] = prometheus_stub
 
 import src.web as web
 


### PR DESCRIPTION
## Summary
- integrate `prometheus-client`
- expose metrics in `web.py` and `detect.py`
- add Prometheus & Grafana services and configuration
- document monitoring endpoints
- stub Prometheus in unit tests

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_683ffd24caf4832eacaa6081c6362582