### PR TITLE
Add off-hour energy saver to detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ MYSQL_PASSWORD=kuanjiapo
 INTERVAL_SEC=5
 PERSON_INTERVAL_MIN=10
 FACE_CONF_THR=0.6
+OFF_HOURS_INTERVAL_SEC=15
+FRAME_DIFF_THR=15
 # https certificate (optional)
 SSL_CERTFILE=./certs/server.crt
 SSL_KEYFILE=./certs/server.key


### PR DESCRIPTION
## Summary
- support configurable off-hours interval and frame difference threshold
- skip face detection when scenes don't change
- document `OFF_HOURS_INTERVAL_SEC` and `FRAME_DIFF_THR` in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa1e2d98c832e9a03b9be9b32200e